### PR TITLE
Add EMAIL_FROM_CAMPAIGN and EMAIL_FROM_ACTIVIST env var settings

### DIFF
--- a/agir/api/settings.py
+++ b/agir/api/settings.py
@@ -432,13 +432,8 @@ EMAIL_TEMPLATES = {
 }
 
 EMAIL_FROM = os.environ.get("EMAIL_FROM", "Claudialízate <noreply@preprod.redmexa.com>")
-EMAIL_FROM_LFI = os.environ.get(
-    "EMAIL_FROM_LFI",
-    "La France insoumise <nepasrepondre@preprod.redmexa.com>",
-)
-EMAIL_FROM_MELENCHON_2022 = os.environ.get(
-    "EMAIL_FROM_MELENCHON_2022", "Mélenchon 2022 <nepasrepondre@melenchon2022.fr>"
-)
+EMAIL_FROM_CAMPAIGN = os.environ.get("EMAIL_FROM_CAMPAIGN", EMAIL_FROM)
+EMAIL_FROM_ACTIVIST = os.environ.get("EMAIL_FROM_ACTIVIST", EMAIL_FROM)
 EMAIL_SECRETARIAT = os.environ.get("EMAIL_SECRETARIAT", "nospam@preprod.redmexa.com")
 EMAIL_EQUIPE_FINANCE = os.environ.get(
     "EMAIL_EQUIPE_FINANCE", "nospam@preprod.redmexa.com"

--- a/agir/donations/tasks.py
+++ b/agir/donations/tasks.py
@@ -58,7 +58,7 @@ def send_monthly_donation_confirmation_email(
     data,
     confirmation_view_name="monthly_donation_confirm",
     email_template="donations/confirmation_email.html",
-    from_email=settings.EMAIL_FROM_LFI,
+    from_email=settings.EMAIL_FROM_CAMPAIGN,
 ):
     data = data.copy()
     email = data.pop("email")

--- a/agir/payments/management/commands/export_payments.py
+++ b/agir/payments/management/commands/export_payments.py
@@ -219,7 +219,7 @@ class Command(LoggingCommand):
                 message = EmailMessage(
                     subject=f"Export des paiements",
                     body=MESSAGE_BODY,
-                    from_email=settings.EMAIL_FROM_LFI,
+                    from_email=settings.EMAIL_FROM_CAMPAIGN,
                     to=[e],
                     connection=connection,
                 )

--- a/agir/payments/management/commands/export_subscriptions.py
+++ b/agir/payments/management/commands/export_subscriptions.py
@@ -147,7 +147,7 @@ class Command(BaseCommand):
                     message = EmailMessage(
                         subject=f"Export des abonnements — {month[0].strftime('%m/%Y')}",
                         body=MESSAGE_BODY,
-                        from_email=settings.EMAIL_FROM_LFI,
+                        from_email=settings.EMAIL_FROM_CAMPAIGN,
                         to=[e],
                         connection=connection,
                     )

--- a/agir/people/actions/subscription.py
+++ b/agir/people/actions/subscription.py
@@ -71,7 +71,7 @@ SUBSCRIPTIONS_EMAILS = {
         "confirmation": SubscriptionMessageInfo(
             code="SUBSCRIPTION__CAMPAIGN__CONFIRMATION_MESSAGE",
             subject="Confirma tu email para ingresar a Claudialízate",
-            from_email=settings.EMAIL_FROM_LFI,
+            from_email=settings.EMAIL_FROM_CAMPAIGN,
         ),
         "welcome": SubscriptionMessageInfo(
             "SUBSCRIPTION__CAMPAIGN__WELCOME_MESSAGE",
@@ -82,7 +82,7 @@ SUBSCRIPTIONS_EMAILS = {
         "confirmation": SubscriptionMessageInfo(
             code="SUBSCRIPTION__ACTIVIST__CONFIRMATION_MESSAGE",
             subject="Confirmez votre e-mail pour valider votre signature !",
-            from_email=settings.EMAIL_FROM_MELENCHON_2022,
+            from_email=settings.EMAIL_FROM_ACTIVIST,
         )
     },
     SUBSCRIPTION_TYPE_EXTERNAL: {},

--- a/agir/presidentielle2022/apps.py
+++ b/agir/presidentielle2022/apps.py
@@ -34,7 +34,7 @@ class Presidentielle2022Config(AppConfig):
                 status_listener=notification_listener,
                 description_template="presidentielle2022/donations/description.html",
                 email_template_code="DONATION_MESSAGE_2022",
-                email_from=settings.EMAIL_FROM_MELENCHON_2022,
+                email_from=settings.EMAIL_FROM_ACTIVIST,
             )
         )
 
@@ -47,7 +47,7 @@ class Presidentielle2022Config(AppConfig):
                 description_template="presidentielle2022/donations/description.html",
                 matomo_goal=settings.MONTHLY_DONATION_MATOMO_GOAL,
                 email_template_code="DONATION_MESSAGE_2022",
-                email_from=settings.EMAIL_FROM_MELENCHON_2022,
+                email_from=settings.EMAIL_FROM_ACTIVIST,
             )
         )
 


### PR DESCRIPTION
When subscribing from an external website, it is possible to choose a subscription type, in particular one for the __campaign__, one for the __activist__ and one for __external__ websites. 

For the __campaign__ and __activist__ type, an email address can be specified to be used as the sender for the subscription confirmation e-mail : this is possible through the environment variables `EMAIL_FROM_CAMPAIGN` and `EMAIL_FROM_ACTIVIST`. 

Both are optional and both default to the address used throughout the platform and defined through the `EMAIL_FROM` variable.